### PR TITLE
20250709_#3_전역예외처리_구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+
+
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/wardk/meeteam_backend/exception/CustomException.java
+++ b/src/main/java/com/wardk/meeteam_backend/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.wardk.meeteam_backend.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/wardk/meeteam_backend/exception/ErrorCode.java
+++ b/src/main/java/com/wardk/meeteam_backend/exception/ErrorCode.java
@@ -1,0 +1,28 @@
+package com.wardk.meeteam_backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+
+    // GLOBAL
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버에 문제가 발생했습니다."),
+
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400", "잘못된 요청입니다."),
+
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMMON403","접근이 거부되었습니다")
+    ;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wardk/meeteam_backend/exception/ErrorResponse.java
+++ b/src/main/java/com/wardk/meeteam_backend/exception/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.wardk.meeteam_backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private String code;
+    private String message;
+
+    public static ErrorResponse getResponse(String code, String message) {
+        return ErrorResponse.builder()
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/wardk/meeteam_backend/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/wardk/meeteam_backend/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.wardk.meeteam_backend.exception.handler;
+
+import com.wardk.meeteam_backend.exception.CustomException;
+import com.wardk.meeteam_backend.exception.ErrorCode;
+import com.wardk.meeteam_backend.exception.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+
+        log.error("CustomException 발생={}",e.getMessage(),e);
+
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = ErrorResponse.getResponse(errorCode.getCode(), errorCode.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+
+    }
+
+
+
+}


### PR DESCRIPTION
### ✅ 작업 내용
- `@ControllerAdvice`와 `@ExceptionHandler`를 활용하여 전역 예외 처리 클래스 `GlobalExceptionHandler`를 구현함.
- `CustomException` 처리 로직 추가
- `ErrorCode` Enum 기반의 공통 에러 응답 구조 적용
- 응답 클래스 `ErrorResponse` 생성

### 📁 주요 변경 파일
- `GlobalExceptionHandler.java`
- `ErrorCode.java`
- `ErrorResponse.java`
- `CustomException.java`

### 🧪 테스트
- 인증 실패 시 401 응답 확인
- 잘못된 요청 시 400 응답 확인
- 서버 내부 오류 시 500 응답 확인

### 💬 기타 논의
- 추후 Validation 에러 처리용 커스텀 예외 추가 예정
- API 응답 포맷 통일 이슈와 연계 가능