### PR TITLE
20250825 #49 기능추가 메인페이지 프로젝트 필터링 pr

### DIFF
--- a/src/main/java/com/wardk/meeteam_backend/domain/mainpage/service/MainPageService.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/mainpage/service/MainPageService.java
@@ -1,0 +1,19 @@
+package com.wardk.meeteam_backend.domain.mainpage.service;
+
+import com.wardk.meeteam_backend.web.mainpage.dto.MainPageProjectDto;
+import com.wardk.meeteam_backend.web.mainpage.dto.SliceResponse;
+import org.springframework.data.domain.Pageable;
+
+
+import java.util.List;
+
+public interface MainPageService {
+
+    /*
+      대분류별 모집중인 프로젝트 조회
+      @param bigCategoryIds 대분류 ID 리스트 (필수)
+      @param pageable 페이징 정보
+      @return 프로젝트 목록 응답
+     */
+    SliceResponse<MainPageProjectDto> getRecruitingProjectsByCategory(List<Long> bigCategoryIds, Pageable pageable);
+}

--- a/src/main/java/com/wardk/meeteam_backend/domain/mainpage/service/MainPageServiceImpl.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/mainpage/service/MainPageServiceImpl.java
@@ -1,0 +1,47 @@
+package com.wardk.meeteam_backend.domain.mainpage.service;
+
+import com.wardk.meeteam_backend.domain.project.entity.Project;
+import com.wardk.meeteam_backend.domain.project.entity.Recruitment;
+import com.wardk.meeteam_backend.domain.project.repository.ProjectRepository;
+import com.wardk.meeteam_backend.global.exception.CustomException;
+import com.wardk.meeteam_backend.global.response.ErrorCode;
+import com.wardk.meeteam_backend.web.mainpage.dto.MainPageProjectDto;
+import com.wardk.meeteam_backend.web.mainpage.dto.SliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MainPageServiceImpl implements MainPageService {
+
+    private final ProjectRepository projectRepository;
+
+    @Override
+    public SliceResponse<MainPageProjectDto> getRecruitingProjectsByCategory(List<Long> bigCategoryIds, Pageable pageable) {
+        // 대분류 파라미터 필수 검증
+        if (bigCategoryIds == null || bigCategoryIds.isEmpty()) {
+            throw new CustomException(ErrorCode.MAIN_PAGE_CATEGORY_NOT_FOUND);
+        }
+
+        // 대분류별 + 모집중 상태 프로젝트 조회
+        Slice<Project> projectSlice = projectRepository.findRecruitingProjectsByBigCategories(
+                bigCategoryIds,
+                Recruitment.RECRUITING,  // Enum 직접 전달
+                pageable
+        );
+
+        // DTO 변환 (기존 ProjectListResponse 방식 참고)
+        List<MainPageProjectDto> dtoList = projectSlice.getContent().stream()
+                .map(MainPageProjectDto::responseDto)  // 정적 메서드 사용
+                .collect(Collectors.toList());
+
+        return SliceResponse.of(dtoList, projectSlice.hasNext(), projectSlice.getNumber());
+    }
+}

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepository.java
@@ -3,10 +3,14 @@ package com.wardk.meeteam_backend.domain.project.repository;
 import com.wardk.meeteam_backend.domain.applicant.entity.ProjectCategoryApplication;
 import com.wardk.meeteam_backend.domain.project.entity.Project;
 import com.wardk.meeteam_backend.domain.project.entity.ProjectSkill;
+import com.wardk.meeteam_backend.domain.project.entity.Recruitment;
 import com.wardk.meeteam_backend.domain.projectMember.entity.ProjectMember;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,4 +40,23 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     @Query("SELECT r FROM ProjectCategoryApplication r JOIN FETCH r.subCategory WHERE r.project.id = :projectId")
     List<ProjectCategoryApplication> findRecruitmentsByProjectId(Long projectId);
+
+
+    // 특정 대분류들을 모집하고 있는 프로젝트 조회 (Slice) - 메인페이지용, recruitmentStatus 파라미터 추가
+
+    @Query("SELECT DISTINCT p FROM Project p " +
+            "JOIN FETCH p.creator " +
+            "JOIN FETCH p.recruitments r " +
+            "JOIN FETCH r.subCategory sc " +
+            "JOIN FETCH sc.bigCategory bc " +
+            "WHERE bc.id IN :bigCategoryIds " +
+            "AND p.recruitmentStatus = :recruitmentStatus " +  // Enum 파라미터 추가
+            "AND p.isDeleted = false " +
+            "ORDER BY p.id DESC")
+    Slice<Project> findRecruitingProjectsByBigCategories(
+            @Param("bigCategoryIds") List<Long> bigCategoryIds,
+            @Param("recruitmentStatus") Recruitment recruitmentStatus,  // Enum 파라미터 추가
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/wardk/meeteam_backend/global/response/ErrorCode.java
+++ b/src/main/java/com/wardk/meeteam_backend/global/response/ErrorCode.java
@@ -74,7 +74,12 @@ public enum ErrorCode {
     PROJECT_REPO_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT_REPO404", "해당 프로젝트 저장소를 찾을 수 없습니다."),
     PROJECT_REPO_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PROJECT_REPO400", "이미 등록된 프로젝트 저장소입니다."),
     INVALID_REPO_URL(HttpStatus.BAD_REQUEST, "PROJECT_REPO400", "유효하지 않은 저장소 URL입니다."),
-    FAILED_TO_PARSE_REPO_URL(HttpStatus.BAD_REQUEST, "PROJECT_REPO400", "저장소 URL 파싱에 실패했습니다.");
+    FAILED_TO_PARSE_REPO_URL(HttpStatus.BAD_REQUEST, "PROJECT_REPO400", "저장소 URL 파싱에 실패했습니다."),
+
+    // 메인페이지 관련 에러 코드
+    MAIN_PAGE_INVALID_PAGINATION(HttpStatus.BAD_REQUEST, "MAIN_PAGE400", "잘못된 페이징 정보입니다."),
+    MAIN_PAGE_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "MAIN_PAGE400", "대분류 정보가 필요합니다."),
+    MAIN_PAGE_SORT_PARAMETER_INVALID(HttpStatus.BAD_REQUEST, "MAIN_PAGE400", "정렬 기준이 올바르지 않습니다.");
 
     ErrorCode(HttpStatus status, String code, String message) {
         this.status = status;

--- a/src/main/java/com/wardk/meeteam_backend/web/mainpage/controller/MainPageController.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/mainpage/controller/MainPageController.java
@@ -1,0 +1,78 @@
+package com.wardk.meeteam_backend.web.mainpage.controller;
+
+import com.wardk.meeteam_backend.domain.mainpage.service.MainPageService;
+import com.wardk.meeteam_backend.global.exception.CustomException;
+import com.wardk.meeteam_backend.global.response.ErrorCode;
+import com.wardk.meeteam_backend.web.mainpage.dto.MainPageProjectDto;
+import com.wardk.meeteam_backend.web.mainpage.dto.SliceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Tag(name = "mainpage-controller", description = "메인페이지 API")
+@RestController
+@RequestMapping("/api/main")
+@RequiredArgsConstructor
+public class MainPageController {
+
+    private final MainPageService mainPageService;
+
+    // 대분류별(sub-category 별)
+    @Operation(summary = "대분류별 프로젝트 목록 조회", description = "대분류 필터링을 통한 모집중인 프로젝트 목록을 무한 스크롤로 조회합니다.")
+    @GetMapping("/projects")
+    public ResponseEntity<SliceResponse<MainPageProjectDto>> getMainPageProjects(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            // 한 번에 가져올 데이터 개수
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+
+            // 정렬할 필드명 (기본값: "createdAt" - 생성일시)
+            @Parameter(description = "정렬 기준", example = "createdAt")
+            @RequestParam(defaultValue = "createdAt") String sort,
+
+            // 정렬 방향 (기본값: "desc" - 내림차순)
+            @Parameter(description = "정렬 방향", example = "desc")
+            @RequestParam(defaultValue = "desc") String direction,
+
+            @Parameter(description = "대분류 ID 목록 (필수)", example = "[3, 4]", required = true)
+            @RequestParam List<Long> bigCategoryIds) {
+
+        // 파라미터 검증
+        if (page < 0 || size <= 0 || size > 50) {
+            throw new CustomException(ErrorCode.MAIN_PAGE_INVALID_PAGINATION);
+        }
+
+        // createdAt 기준으로 정렬 파라미터 검증 수정
+        if (!Arrays.asList("createdAt", "name").contains(sort)) {
+            throw new CustomException(ErrorCode.MAIN_PAGE_SORT_PARAMETER_INVALID);
+        }
+
+        // 유효하지 않은 ID(0이하)가 하나라도 있으면 에러
+        if (bigCategoryIds.stream().anyMatch(id -> id <= 0)) {
+            throw new CustomException(ErrorCode.MAIN_PAGE_CATEGORY_NOT_FOUND);
+        }
+
+        // direction이 "desc"이면 DESC, 아니면 ASC , equalsIgnoreCase(): 대소문자 구분 없이 비교
+        Sort.Direction sortDirection = direction.equalsIgnoreCase("desc")
+                ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+
+        SliceResponse<MainPageProjectDto> response = mainPageService.getRecruitingProjectsByCategory(bigCategoryIds, pageable);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/wardk/meeteam_backend/web/mainpage/dto/MainPageProjectDto.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/mainpage/dto/MainPageProjectDto.java
@@ -1,0 +1,56 @@
+package com.wardk.meeteam_backend.web.mainpage.dto;
+
+import com.wardk.meeteam_backend.domain.project.entity.Project;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MainPageProjectDto { // 프로젝트 카드 정보
+    private String id; // JavaScript 정밀도 문제 해결을 위해 String 사용
+    private String name;
+    private String description;
+    private String projectCategory;
+    private String platformCategory;
+    private String imageUrl;
+    private String creatorName;
+    private LocalDateTime createdDate;
+    private LocalDate endDate;
+    private List<String> skillNames;
+    private List<RecruitmentInfoDto> recruitmentInfo;
+
+    public static MainPageProjectDto responseDto(Project project) {
+        return MainPageProjectDto.builder()
+                .id(String.valueOf(project.getId()))
+                .name(project.getName())
+                .description(project.getDescription())
+                .projectCategory(project.getProjectCategory().name())
+                .platformCategory(project.getPlatformCategory().name())
+                .imageUrl(project.getImageUrl())
+                .creatorName(project.getCreator().getRealName())
+                .createdDate(project.getCreatedAt())
+                .endDate(project.getEndDate())
+                .skillNames(
+                        project.getProjectSkills() != null
+                                ? project.getProjectSkills().stream()
+                                .map(ps -> ps.getSkill().getSkillName())
+                                .collect(Collectors.toList())
+                                : List.of()
+                )
+                .recruitmentInfo(
+                        project.getRecruitments() != null
+                                ? project.getRecruitments().stream()
+                                .map(RecruitmentInfoDto::responseDto)
+                                .collect(Collectors.toList())
+                                : List.of()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/wardk/meeteam_backend/web/mainpage/dto/RecruitmentInfoDto.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/mainpage/dto/RecruitmentInfoDto.java
@@ -1,0 +1,26 @@
+package com.wardk.meeteam_backend.web.mainpage.dto;
+
+import com.wardk.meeteam_backend.domain.applicant.entity.ProjectCategoryApplication;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentInfoDto { // 모집 현황 정보
+    private String subCategoryName;
+    private Integer recruitmentCount;
+    private Integer currentCount;
+
+    /**
+     * ProjectCategoryApplication을 RecruitmentInfoDto로 변환하는 정적 메서드
+     */
+    public static RecruitmentInfoDto responseDto(ProjectCategoryApplication recruitment) {
+        return RecruitmentInfoDto.builder()
+                .subCategoryName(recruitment.getSubCategory().getName())
+                .recruitmentCount(recruitment.getRecruitmentCount())
+                .currentCount(recruitment.getCurrentCount())
+                .build();
+    }
+}

--- a/src/main/java/com/wardk/meeteam_backend/web/mainpage/dto/SliceResponse.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/mainpage/dto/SliceResponse.java
@@ -1,0 +1,26 @@
+package com.wardk.meeteam_backend.web.mainpage.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SliceResponse<T> { // 무한 스크롤용 페이징 응답 래퍼
+    private List<T> content;
+    private Boolean hasNext;
+    private Integer currentPage;
+    private Integer size;
+
+    public static <T> SliceResponse<T> of(List<T> contents, Boolean hasNext, Integer currentPage) {
+        return SliceResponse.<T>builder()
+                .content(contents)
+                .hasNext(hasNext)
+                .currentPage(currentPage)
+                .size(contents.size())
+                .build();
+    }
+}


### PR DESCRIPTION
# 📝 메인페이지 대분류별 프로젝트 목록 API

## 🎯 기능 개요

- **대분류 ID**를 기반으로 모집중인 프로젝트 목록을 **무한스크롤** 형태로 조회하는 API 구현
- **페이징, 정렬, 필터링** 기능 포함

---

## ✨ 주요 변경사항

1. **API 엔드포인트 추가**
   - `GET /api/main/projects`
   - 대분류별 모집중인 프로젝트 조회 (페이징/정렬 지원)

2. **구현 파일**

📁 domain/mainpage/service/
├── MainPageService.java (Interface)
└── MainPageServiceImpl.java

📁 web/mainpage/
├── controller/MainPageController.java
└── dto/
├── MainPageProjectDto.java
├── RecruitmentInfoDto.java
└── SliceResponse.java

📁 domain/project/repository/
└── ProjectRepository.java (메서드 추가)



3. **기술적 개선**
- **MultipleBagFetchException** 해결 (다중 컬렉션 Fetch Join 문제 제거)
- **N+1 쿼리 문제** 방지 (JOIN FETCH 최적화)
- **ID의 String 변환**으로 JS 정밀도 문제 해결

---

## 🔧 API 스펙

### Request Parameters

| 파라미터         | 타입       | 설명                       | 비고               |
|------------------|------------|----------------------------|--------------------|
| page             | int        | 페이지 번호                | 기본값: 0          |
| size             | int        | 페이지 크기                | 기본값: 10         |
| sort             | string     | 정렬 기준 ("createdAt", "name") | 기본값: createdAt |
| direction        | string     | 정렬 방향 ("asc", "desc")  | 기본값: desc       |
| bigCategoryIds   | List\<Long\> | 대분류 ID 목록 (필수)      |  예: bigCategoryIds=3,4 |

### Response

{
"content": [ ...프로젝트 목록... ],
"hasNext": true,
"currentPage": 0,
"size": 10
}



### 필수 및 주의사항
- `bigCategoryIds`는 **필수 파라미터** (없으면 400 에러)
- **ID는 문자열**: 비교 시 `===` 사용 권장
- **page는 0부터 시작**
- **hasNext=false**일 때 더 이상 데이터 호출 X