### PR TITLE
20250915 #119 프로젝트 좋아요 동시성 문제해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ out/
 .vscode/
 
 ### application.yml ###
-src/main/resources/application.yml
+src/main/resources/application-local.yml
 src/main/resources/application-prod.yml
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,11 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 
+	// datafacker
+	implementation 'net.datafaker:datafaker:2.3.1' // 최신 2.x 사용 권장
+
+
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'com.h2database:h2'
 
 
 	//Querydsl 추가

--- a/src/main/java/com/wardk/meeteam_backend/domain/member/repository/SubCategoryRepository.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/member/repository/SubCategoryRepository.java
@@ -4,10 +4,13 @@ import com.wardk.meeteam_backend.domain.category.entity.SubCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SubCategoryRepository extends JpaRepository<SubCategory, Long> {
 
     Optional<SubCategory> findByName(String subCategory);
+
+    List<SubCategory> findByNameIn(List<String> subNames);
 }

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/entity/Project.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/entity/Project.java
@@ -3,6 +3,7 @@ package com.wardk.meeteam_backend.domain.project.entity;
 import com.wardk.meeteam_backend.domain.applicant.entity.ProjectCategoryApplication;
 import com.wardk.meeteam_backend.domain.member.entity.Member;
 import com.wardk.meeteam_backend.domain.pr.entity.ProjectRepo;
+import com.wardk.meeteam_backend.domain.projectLike.entity.ProjectLike;
 import com.wardk.meeteam_backend.domain.projectMember.entity.ProjectMember;
 import com.wardk.meeteam_backend.domain.projectMember.entity.ProjectMemberApplication;
 import com.wardk.meeteam_backend.domain.review.entity.Review;
@@ -66,8 +67,6 @@ public class Project extends BaseEntity {
     @Column(nullable = false)
     private Integer likeCount = 0;
 
-    @Version
-    private Long version;
 
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -78,6 +77,9 @@ public class Project extends BaseEntity {
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectSkill> projectSkills = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectLike> projectLikes = new ArrayList<>();
 
     @OneToMany(mappedBy = "project")
     private List<Review> reviews = new ArrayList<>();

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/entity/ProjectSkill.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/entity/ProjectSkill.java
@@ -2,11 +2,14 @@ package com.wardk.meeteam_backend.domain.project.entity;
 
 import com.wardk.meeteam_backend.domain.skill.entity.Skill;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProjectSkill {//프로젝트_기술_스택_테이블(중간테이블)
 
     @Id
@@ -14,12 +17,12 @@ public class ProjectSkill {//프로젝트_기술_스택_테이블(중간테이�
     @Column(name = "project_skill_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
     private Project project;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "skill_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "skill_id", nullable = false)
     private Skill skill;
 
     @Builder
@@ -27,14 +30,16 @@ public class ProjectSkill {//프로젝트_기술_스택_테이블(중간테이�
         this.skill = skill;
     }
 
-    public ProjectSkill() {
-
-    }
-
     public static ProjectSkill createProjectSkill(Skill skill) {
         return ProjectSkill.builder()
                 .skill(skill)
                 .build();
+    }
+
+    public static ProjectSkill create(Project project, Skill skill) {
+        ProjectSkill ps = new ProjectSkill(skill);
+        ps.assignProject(project);
+        return ps;
     }
 
     public void assignProject(Project project) {

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/entity/TechStack.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/entity/TechStack.java
@@ -1,0 +1,74 @@
+package com.wardk.meeteam_backend.domain.project.entity;
+
+public enum TechStack {
+    ANSIBLE("Ansible"),
+    AWS("AWS"),
+    DOCKER("Docker"),
+    ELASTICSEARCH("Elasticsearch"),
+    EXPRESS("Express"),
+    GIT("Git"),
+    GITHUB_ACTIONS("GitHub Actions"),
+    GRADLE("Gradle"),
+    GRAFANA("Grafana"),
+    GRAPHQL("GraphQL"),
+    GRPC("gRPC"),
+    HIBERNATE("Hibernate"),
+    HTML_CSS("HTML/CSS"),
+    JAVA("Java"),
+    JAVASCRIPT("JavaScript"),
+    JENKINS("Jenkins"),
+    JPA("JPA"),
+    JUNIT5("JUnit 5"),
+    JWT("JWT"),
+    KAFKA("Kafka"),
+    KIBANA("Kibana"),
+    KOTLIN("Kotlin"),
+    KUBERNETES("Kubernetes"),
+    LINUX("Linux"),
+    LOGSTASH("Logstash"),
+    MAVEN("Maven"),
+    MICROMETER("Micrometer"),
+    MOCKITO("Mockito"),
+    MONGODB("MongoDB"),
+    MYSQL("MySQL"),
+    NEXT_JS("Next.js"),
+    NGINX("Nginx"),
+    NODE_JS("Node.js"),
+    OAUTH2("OAuth2"),
+    OPENAPI_SWAGGER("OpenAPI/Swagger"),
+    POSTGRESQL("PostgreSQL"),
+    PROMETHEUS("Prometheus"),
+    PYTHON("Python"),
+    QUERYDSL("QueryDSL"),
+    RABBITMQ("RabbitMQ"),
+    REACT("React"),
+    REDIS("Redis"),
+    SPRING("Spring"),
+    SPRING_BOOT("Spring Boot"),
+    SSE("SSE"),
+    TAILWIND_CSS("Tailwind CSS"),
+    TERRAFORM("Terraform"),
+    TYPESCRIPT("TypeScript"),
+    WEBFLUX("WebFlux"),
+    WEBSOCKET("WebSocket");
+
+    private final String techName;
+
+    TechStack(String techName) {
+        this.techName = techName;
+    }
+
+    public String getTechName() {
+        return techName;
+    }
+
+    // name 으로 Enum 찾기
+    public static TechStack fromName(String name) {
+        for (TechStack stack : values()) {
+            if (stack.techName.equalsIgnoreCase(name)) {
+                return stack;
+            }
+        }
+        throw new IllegalArgumentException("Invalid tech name: " + name);
+    }
+}

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepository.java
@@ -5,14 +5,13 @@ import com.wardk.meeteam_backend.domain.project.entity.Project;
 import com.wardk.meeteam_backend.domain.project.entity.ProjectSkill;
 import com.wardk.meeteam_backend.domain.project.entity.Recruitment;
 import com.wardk.meeteam_backend.domain.projectMember.entity.ProjectMember;
+import com.wardk.meeteam_backend.web.projectLike.dto.ProjectWithLikeDto;
 import jakarta.persistence.Entity;
+import jakarta.persistence.LockModeType;
 import jakarta.persistence.OneToMany;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
@@ -69,6 +68,14 @@ public interface ProjectRepository extends JpaRepository<Project, Long> , Projec
             "WHERE p IN :projects")
     List<Project> findProjectsWithSkills(@Param("projects") List<Project> projects);
 
+    @Query("""
+       SELECT new com.wardk.meeteam_backend.web.projectLike.dto.ProjectWithLikeDto(p, COUNT(pl))
+       FROM Project p
+       LEFT JOIN p.projectLikes pl
+       WHERE p.id = :projectId
+       GROUP BY p
+       """)
+    Optional<ProjectWithLikeDto> findProjectWithLikeCount(@Param("projectId") Long projectId);
 
     // 테스트 용도
     @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -79,4 +86,9 @@ public interface ProjectRepository extends JpaRepository<Project, Long> , Projec
             @Param("id") Long id,
             @Param("ts") java.time.LocalDateTime ts
     );
+
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Project p where p.id = :id")
+    Optional<Project> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepository.java
@@ -11,9 +11,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -67,4 +69,14 @@ public interface ProjectRepository extends JpaRepository<Project, Long> , Projec
             "WHERE p IN :projects")
     List<Project> findProjectsWithSkills(@Param("projects") List<Project> projects);
 
+
+    // 테스트 용도
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "update Project p set p.createdAt = :ts where p.id = :id"
+    )
+    void overrideTimestamps(
+            @Param("id") Long id,
+            @Param("ts") java.time.LocalDateTime ts
+    );
 }

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.wardk.meeteam_backend.domain.project.repository;
 
+import com.wardk.meeteam_backend.domain.project.entity.Project;
 import com.wardk.meeteam_backend.web.project.dto.ProjectSearchCondition;
 import com.wardk.meeteam_backend.web.project.dto.ProjectSearchResponse;
 import org.springframework.data.domain.Pageable;
@@ -8,5 +9,5 @@ import org.springframework.data.domain.Slice;
 public interface ProjectRepositoryCustom {
 
 
-    Slice<ProjectSearchResponse> findAllSlicedForSearchAtCondition(ProjectSearchCondition condition, Pageable pageable);
+    Slice<Project> findAllSlicedForSearchAtCondition(ProjectSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepositoryImpl.java
@@ -7,10 +7,6 @@ import com.wardk.meeteam_backend.domain.project.entity.*;
 import com.wardk.meeteam_backend.web.project.dto.ProjectSearchCondition;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
-
-import java.util.List;
-
 import static com.wardk.meeteam_backend.domain.applicant.entity.QProjectCategoryApplication.*;
 import static com.wardk.meeteam_backend.domain.category.entity.QBigCategory.*;
 import static com.wardk.meeteam_backend.domain.category.entity.QSubCategory.*;
@@ -21,14 +17,12 @@ import static com.wardk.meeteam_backend.domain.skill.entity.QSkill.skill;
 
 public class ProjectRepositoryImpl extends Querydsl4RepositorySupport implements ProjectRepositoryCustom {
 
-
     private final JPAQueryFactory queryFactory;
 
     public ProjectRepositoryImpl(JPAQueryFactory queryFactory) {
         super(Project.class);
         this.queryFactory = queryFactory;
     }
-
     @Override
     public Slice<Project> findAllSlicedForSearchAtCondition(ProjectSearchCondition condition, Pageable pageable) {
 
@@ -47,7 +41,6 @@ public class ProjectRepositoryImpl extends Querydsl4RepositorySupport implements
         );
 
         return projects;
-
     }
 
     private BooleanExpression projectTechNameExists(TechStack techStack) {
@@ -91,11 +84,6 @@ public class ProjectRepositoryImpl extends Querydsl4RepositorySupport implements
         return (projectCategory == null) ? null : project.projectCategory.eq(projectCategory);
     }
 
-
-    private BooleanExpression bigCategoryEq(String category) {
-        if (category == null || category.isBlank()) return null;
-        return bigCategory.name.eq(category);
-    }
 
     private BooleanExpression notDeleted() {
         return project.isDeleted.eq(false);

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/repository/ProjectRepositoryImpl.java
@@ -5,10 +5,9 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wardk.meeteam_backend.domain.project.entity.*;
 import com.wardk.meeteam_backend.web.project.dto.ProjectSearchCondition;
-import com.wardk.meeteam_backend.web.project.dto.ProjectSearchResponse;
-import com.wardk.meeteam_backend.web.project.dto.QProjectSearchResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 
@@ -17,6 +16,8 @@ import static com.wardk.meeteam_backend.domain.category.entity.QBigCategory.*;
 import static com.wardk.meeteam_backend.domain.category.entity.QSubCategory.*;
 import static com.wardk.meeteam_backend.domain.member.entity.QMember.*;
 import static com.wardk.meeteam_backend.domain.project.entity.QProject.*;
+import static com.wardk.meeteam_backend.domain.project.entity.QProjectSkill.*;
+import static com.wardk.meeteam_backend.domain.skill.entity.QSkill.skill;
 
 public class ProjectRepositoryImpl extends Querydsl4RepositorySupport implements ProjectRepositoryCustom {
 
@@ -29,38 +30,37 @@ public class ProjectRepositoryImpl extends Querydsl4RepositorySupport implements
     }
 
     @Override
-    public Slice<ProjectSearchResponse> findAllSlicedForSearchAtCondition(ProjectSearchCondition condition, Pageable pageable) {
+    public Slice<Project> findAllSlicedForSearchAtCondition(ProjectSearchCondition condition, Pageable pageable) {
 
-        // 1) ID 선조회
-        List<Long> ids = queryFactory
-                .select(project.id)
-                .from(project)
-                .where(
-                        notDeleted(),
-                        platformCategoryEq(condition.getPlatformCategory()),
-                        recruitmentEq(condition.getRecruitment()),
-                        bigCategoryExists(condition.getBigCategory()),
-                        projectCategoryEq(condition.getProjectCategory())
-                )
-                .fetch();
-
-
-        // 2) 본문조회 → applySlicing에 위임
-        return applySlicing(pageable, queryFactory ->
-                queryFactory
-                        .select(new QProjectSearchResponse(
-                                project.id,
-                                project.platformCategory,
-                                project.name,
-                                member.realName,
-                                project.createdAt,
-                                project.projectCategory
-                        ))
+        Slice<Project> projects = applySlicing(pageable, qf ->
+                qf.select(project)
                         .from(project)
-                        .join(project.creator, member)
-                        .where(project.id.in(ids))
+                        .join(project.creator, member).fetchJoin()
+                        .where(
+                                notDeleted(),
+                                platformCategoryEq(condition.getPlatformCategory()),
+                                recruitmentEq(condition.getRecruitment()),
+                                projectTechNameExists(condition.getTechStack()),
+                                bigCategoryExists(condition.getBigCategory()),
+                                projectCategoryEq(condition.getProjectCategory())
+                        )
         );
 
+        return projects;
+
+    }
+
+    private BooleanExpression projectTechNameExists(TechStack techStack) {
+        if (techStack == null) return null;
+        return JPAExpressions
+                .selectOne()
+                .from(projectSkill)
+                .leftJoin(projectSkill.skill,skill)
+                .where(
+                        projectSkill.project.eq(project),
+                        skill.skillName.eq(techStack.getTechName())
+                )
+                .exists();
     }
 
     private BooleanExpression bigCategoryExists(String bigCategoryName) {

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/repository/Querydsl4RepositorySupport.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/repository/Querydsl4RepositorySupport.java
@@ -25,13 +25,6 @@ import java.util.List;
 import java.util.function.Function;
 
 
-/**
- * Querydsl 4.x 버전에 맞춘 Querydsl 지원 라이브러리 *
- * @author Younghan Kim
- * @see org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
- */
-
-
 @Repository
 public abstract class Querydsl4RepositorySupport {
 

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/service/ProjectService.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/service/ProjectService.java
@@ -26,9 +26,10 @@ public interface ProjectService {
     // 메인 페이지용 메서드
     @Transactional(readOnly = true)
     SliceResponse<MainPageProjectDto> getRecruitingProjectsByCategory(Long bigCategoryId, Pageable pageable);
-    Slice<ProjectSearchResponse> searchProject(ProjectSearchCondition condition, Pageable pageable);
+
 
     // 참여중, 종료된 프로젝트 조회
     List<MyProjectResponse> getMyProject(CustomSecurityUserDetails userDetails);
+    Slice<ProjectConditionRequest> searchProject(ProjectSearchCondition condition, Pageable pageable);
 }
 

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/service/ProjectService.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/service/ProjectService.java
@@ -5,6 +5,7 @@ import com.wardk.meeteam_backend.global.auth.dto.CustomSecurityUserDetails;
 import com.wardk.meeteam_backend.web.mainpage.dto.MainPageProjectDto;
 import com.wardk.meeteam_backend.web.mainpage.dto.SliceResponse;
 import com.wardk.meeteam_backend.web.project.dto.*;
+import com.wardk.meeteam_backend.web.projectLike.dto.ProjectWithLikeDto;
 import com.wardk.meeteam_backend.web.projectMember.dto.ProjectUpdateResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +19,6 @@ public interface ProjectService {
 
     ProjectPostResponse postProject(ProjectPostRequest projectPostRequest, MultipartFile file, String requesterEmail);
     List<ProjectListResponse> getProjectList();
-    ProjectResponse getProject(Long projectId);
     ProjectUpdateResponse updateProject(Long projectId, ProjectUpdateRequest request, MultipartFile file, String requesterEmail);
     ProjectDeleteResponse deleteProject(Long projectId, String requesterEmail);
     List<ProjectRepoResponse> addRepo(Long projectId, ProjectRepoRequest request, String requesterEmail);
@@ -31,5 +31,9 @@ public interface ProjectService {
     // 참여중, 종료된 프로젝트 조회
     List<MyProjectResponse> getMyProject(CustomSecurityUserDetails userDetails);
     Slice<ProjectConditionRequest> searchProject(ProjectSearchCondition condition, Pageable pageable);
+
+
+    ProjectResponse getProjectV1(Long projectId);
+    ProjectWithLikeDto getProjectV2(Long projectId);
 }
 

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/service/ProjectServiceImpl.java
@@ -27,7 +27,6 @@ import com.wardk.meeteam_backend.web.project.dto.*;
 import com.wardk.meeteam_backend.web.projectMember.dto.ProjectUpdateResponse;
 import io.micrometer.core.annotation.Counted;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -231,19 +230,15 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public Slice<ProjectSearchResponse> searchProject(ProjectSearchCondition condition, Pageable pageable) {
+    public Slice<ProjectConditionRequest> searchProject(ProjectSearchCondition condition, Pageable pageable) {
 
-        Slice<ProjectSearchResponse> content = projectRepository.findAllSlicedForSearchAtCondition(condition, pageable);
+        Slice<Project> content = projectRepository.findAllSlicedForSearchAtCondition(condition, pageable);
 
-        content.forEach(
-                dto -> {
-                    Project project = projectRepository.findById(dto.getProjectId())
-                            .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
-                    dto.settingSkills(project);
-                }
+        Slice<ProjectConditionRequest> map = content.map(
+                project -> new ProjectConditionRequest(project)
         );
 
-        return content;
+        return map;
 
     }
 
@@ -285,7 +280,7 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
 
-  @Transactional(readOnly = true)
+    @Transactional(readOnly = true)
     @Override
     public SliceResponse<MainPageProjectDto> getRecruitingProjectsByCategory(Long bigCategoryId, Pageable pageable) {
         if (bigCategoryId == null || bigCategoryId <= 0) {

--- a/src/main/java/com/wardk/meeteam_backend/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/project/service/ProjectServiceImpl.java
@@ -24,6 +24,7 @@ import com.wardk.meeteam_backend.global.util.FileUtil;
 import com.wardk.meeteam_backend.web.mainpage.dto.MainPageProjectDto;
 import com.wardk.meeteam_backend.web.mainpage.dto.SliceResponse;
 import com.wardk.meeteam_backend.web.project.dto.*;
+import com.wardk.meeteam_backend.web.projectLike.dto.ProjectWithLikeDto;
 import com.wardk.meeteam_backend.web.projectMember.dto.ProjectUpdateResponse;
 import io.micrometer.core.annotation.Counted;
 import lombok.RequiredArgsConstructor;
@@ -119,13 +120,24 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public ProjectResponse getProject(Long projectId) {
+    public ProjectResponse getProjectV1(Long projectId) {
 
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
 
 
         return ProjectResponse.responseDto(project);
+    }
+
+
+    @Override
+    public ProjectWithLikeDto getProjectV2(Long projectId) {
+
+        ProjectWithLikeDto projectWithLikeDto = projectRepository.findProjectWithLikeCount(projectId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
+
+
+        return projectWithLikeDto;
     }
 
     @Override

--- a/src/main/java/com/wardk/meeteam_backend/domain/projectLike/repository/ProjectLikeRepository.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/projectLike/repository/ProjectLikeRepository.java
@@ -1,5 +1,7 @@
 package com.wardk.meeteam_backend.domain.projectLike.repository;
 
+import com.wardk.meeteam_backend.domain.member.entity.Member;
+import com.wardk.meeteam_backend.domain.project.entity.Project;
 import com.wardk.meeteam_backend.domain.projectLike.entity.ProjectLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +11,7 @@ public interface ProjectLikeRepository extends JpaRepository<ProjectLike, Long> 
 
     Optional<ProjectLike> findByMemberIdAndProjectId(Long memberId, Long projectId);
     long deleteByMemberIdAndProjectId(Long memberId, Long projectId);
+
+    Integer countByProjectId(Long projectId);
+    Optional<ProjectLike> findByMemberAndProject(Member member, Project project);
 }

--- a/src/main/java/com/wardk/meeteam_backend/domain/projectLike/service/ProjectLikeService.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/projectLike/service/ProjectLikeService.java
@@ -15,6 +15,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class ProjectLikeService {
@@ -24,46 +26,58 @@ public class ProjectLikeService {
     private final MemberRepository memberRepository;
 
 
-    /**
-     * 좋아요 토글
-     */
-    @Retry
+
     @Transactional
-    public ToggleLikeResponse toggle(Long projectId, String email) {
-        Project project = projectRepository.findById(projectId)
+    public ToggleLikeResponse toggleWithPessimistic(Long projectId, String email) {
+        Project project = projectRepository.findByIdForUpdate(projectId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
 
-        // userName → memberId 해석 (JWT에서 전달된 userName 기준)
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        Long memberId = member.getId();
+        // 1) Optional 로 좋아요 여부 확인
+        Optional<ProjectLike> existing = projectLikeRepository.findByMemberAndProject(member, project);
 
-        // 1) 이미 눌렀으면 삭제 먼저 (영향 행 수로 판별)
-        long deleted = projectLikeRepository.deleteByMemberIdAndProjectId(memberId, projectId);
-        if (deleted > 0) {
-            project.decreaseLike(); // @Version 충돌 시 AOP 재시도
+        if (existing.isPresent()) {
+            // 이미 눌렀으면 삭제
+            projectLikeRepository.delete(existing.get());
+            project.decreaseLike();
             return new ToggleLikeResponse(projectId, false, project.getLikeCount());
         }
 
-        // 2) 없으면 삽입 시도 (동시성에서 유니크 제약 위반 가능)
-        try {
-            ProjectLike newLike = ProjectLike.create(member, project); // 이미 조회된 영속 엔티티 재사용
-            projectLikeRepository.saveAndFlush(newLike);  // ← 여기서 즉시 제약 위반 감지ㅛ
-            project.increaseLike();
-            return new ToggleLikeResponse(projectId, true, project.getLikeCount());
-        } catch (DataIntegrityViolationException e) {
+        // 2) 없으면 삽입
+        projectLikeRepository.save(ProjectLike.create(member, project));
+        project.increaseLike();
 
-            Project fresh = projectRepository.findById(projectId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
-            return new ToggleLikeResponse(projectId, true, fresh.getLikeCount());
-        }
+        return new ToggleLikeResponse(projectId, true, project.getLikeCount());
     }
 
 
+    @Retry
+    @Transactional
+    public ToggleLikeResponse toggleWithOptimistic(Long projectId, String email) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
 
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
+        // 1) Optional 로 좋아요 여부 확인
+        Optional<ProjectLike> existing = projectLikeRepository.findByMemberAndProject(member, project);
 
+        if (existing.isPresent()) {
+            // 이미 눌렀으면 삭제
+            projectLikeRepository.delete(existing.get());
+            project.decreaseLike();
+            return new ToggleLikeResponse(projectId, false, project.getLikeCount());
+        }
+
+        // 2) 없으면 삽입
+        projectLikeRepository.save(ProjectLike.create(member, project));
+        project.increaseLike();
+
+        return new ToggleLikeResponse(projectId, true, project.getLikeCount());
+    }
 
 
 }

--- a/src/main/java/com/wardk/meeteam_backend/domain/skill/repository/SkillRepository.java
+++ b/src/main/java/com/wardk/meeteam_backend/domain/skill/repository/SkillRepository.java
@@ -4,10 +4,16 @@ import com.wardk.meeteam_backend.domain.skill.entity.Skill;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 @Repository
 public interface SkillRepository extends JpaRepository<Skill, Long> {
 
     Optional<Skill> findBySkillName(String skillName);
+
+    @Query(value = "SELECT * FROM skill ORDER BY RAND() LIMIT :limit", nativeQuery = true)
+    List<Skill> findRandomSkills(@Param("limit") int limit);
 }

--- a/src/main/java/com/wardk/meeteam_backend/global/support/controller/SeedController.java
+++ b/src/main/java/com/wardk/meeteam_backend/global/support/controller/SeedController.java
@@ -1,0 +1,39 @@
+package com.wardk.meeteam_backend.global.support.controller;
+
+
+import com.wardk.meeteam_backend.global.support.service.SeedSevice;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@Profile("local")
+@RestController
+@RequestMapping("/dev/seed")
+@RequiredArgsConstructor
+@Validated
+public class SeedController {
+
+
+    private final SeedSevice seedService;
+
+    /** 예: POST /dev/seed/projects?count=50 */
+    @PostMapping("/projects")
+    public Map<String, Object> seedProjects(
+            @RequestParam(defaultValue = "30") @Min(1) @Max(1000000) int count
+    ) {
+        List<Long> ids = seedService.seedProjects(count);
+        return Map.of(
+                "created", ids.size(),
+                "projectIds", ids
+        );
+    }
+}

--- a/src/main/java/com/wardk/meeteam_backend/global/support/service/SeedSevice.java
+++ b/src/main/java/com/wardk/meeteam_backend/global/support/service/SeedSevice.java
@@ -1,0 +1,166 @@
+package com.wardk.meeteam_backend.global.support.service;
+
+import com.wardk.meeteam_backend.domain.applicant.entity.ProjectCategoryApplication;
+import com.wardk.meeteam_backend.domain.category.entity.SubCategory;
+import com.wardk.meeteam_backend.domain.member.entity.Member;
+import com.wardk.meeteam_backend.domain.member.repository.MemberRepository;
+import com.wardk.meeteam_backend.domain.member.repository.SubCategoryRepository;
+import com.wardk.meeteam_backend.domain.project.entity.PlatformCategory;
+import com.wardk.meeteam_backend.domain.project.entity.Project;
+import com.wardk.meeteam_backend.domain.project.entity.ProjectCategory;
+import com.wardk.meeteam_backend.domain.project.entity.ProjectSkill;
+import com.wardk.meeteam_backend.domain.project.repository.ProjectRepository;
+import com.wardk.meeteam_backend.domain.projectMember.service.ProjectMemberService;
+import com.wardk.meeteam_backend.domain.skill.entity.Skill;
+import com.wardk.meeteam_backend.domain.skill.repository.SkillRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import net.datafaker.Faker;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+
+@Profile("local")
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SeedSevice {
+
+
+    private final ProjectRepository projectRepository;
+    private final MemberRepository memberRepository;
+    private final SubCategoryRepository subCategoryRepository;
+    private final SkillRepository skillRepository;
+    private final ProjectMemberService projectMemberService;
+
+    private final Faker faker = new Faker(new Locale("ko", "KR"));
+
+    // DB에 이미 존재하는 소분류 이름 (표기 정확히 일치)
+    private static final List<String> SUB_NAMES = List.of(
+            "프로덕트 매니저/오너","그래픽디자인","UI/UX디자인","모션 디자인","BX/브랜드 디자인",
+            "웹프론트엔드","iOS","안드로이드","크로스플랫폼","웹서버","AI","DBA/빅데이터/DS","기타"
+    );
+
+    /** 프로젝트 count개 생성하고 생성된 ID 리스트 반환 */
+    public List<Long> seedProjects(int count) {
+        Map<String, SubCategory> subDict = loadSubDictOrThrow();
+        List<Member> creators = ensureSomeMembers(20);
+
+        Optional<Skill> javaOpt = skillRepository.findBySkillName("Java");
+        Optional<Skill> springOpt = skillRepository.findBySkillName("Spring");
+
+        List<Long> createdIds = Collections.synchronizedList(new ArrayList<>(count));
+
+        ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+
+        for (int i = 0; i < count; i++) {
+            executor.submit(() -> {
+                Member creator = pick(creators);
+                LocalDate end = LocalDate.now().plusDays(faker.number().numberBetween(15, 90));
+
+                ProjectCategory projectCat = randomEnum(ProjectCategory.values());
+                PlatformCategory platform = randomEnum(PlatformCategory.values());
+
+                Project project = Project.createProject(
+                        creator,
+                        "hi" + faker.company().buzzword() + " 프로젝트",
+                        faker.lorem().sentence(12),
+                        projectCat,
+                        platform,
+                        null,
+                        faker.bool().bool(),
+                        randomPastDateTime(300).toLocalDate()
+                );
+
+                // 모집 소분류
+                List<String> shuffled = new ArrayList<>(SUB_NAMES);
+                Collections.shuffle(shuffled, faker.random().getRandomInternal());
+                int slots = faker.number().numberBetween(2, 4);
+                for (int k = 0; k < slots; k++) {
+                    SubCategory sc = subDict.get(shuffled.get(k));
+                    int need = faker.number().numberBetween(1, 4);
+                    ProjectCategoryApplication pca = ProjectCategoryApplication.createProjectCategoryApplication(sc, need);
+                    project.addRecruitment(pca);
+                }
+
+                javaOpt.ifPresent(s -> project.addProjectSkill(ProjectSkill.createProjectSkill(s)));
+                springOpt.ifPresent(s -> project.addProjectSkill(ProjectSkill.createProjectSkill(s)));
+
+
+
+                int count2 = ThreadLocalRandom.current().nextInt(1, 3); // 3~8개 랜덤
+                List<Skill> picks = skillRepository.findRandomSkills(count2);
+
+                for (Skill s : picks) {
+                    project.addProjectSkill(ProjectSkill.create(project, s));
+                }
+
+                projectRepository.save(project);
+
+                LocalDateTime ts = randomPastDateTime(90);
+                projectRepository.overrideTimestamps(project.getId(), ts);
+
+                SubCategory creatorSub = subDict.getOrDefault("웹프론트엔드", pick(new ArrayList<>(subDict.values())));
+                projectMemberService.addCreator(project.getId(), creator.getId(), creatorSub);
+
+                createdIds.add(project.getId());
+            });
+        }
+
+        executor.shutdown();
+        try {
+            executor.awaitTermination(1, TimeUnit.HOURS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        return createdIds;
+    }
+
+    // ===== helpers =====
+    private Map<String, SubCategory> loadSubDictOrThrow() {
+        List<SubCategory> list = subCategoryRepository.findByNameIn(SUB_NAMES);
+        Map<String, SubCategory> map = list.stream()
+                .collect(Collectors.toMap(SubCategory::getName, x -> x));
+        List<String> missing = SUB_NAMES.stream().filter(n -> !map.containsKey(n)).toList();
+        if (!missing.isEmpty()) throw new IllegalStateException("DB에 없는 소분류: " + missing);
+        return map;
+    }
+
+    private List<Member> ensureSomeMembers(int n) {
+        List<Member> existed = memberRepository.findAll();
+        if (!existed.isEmpty()) return existed;
+
+        List<Member> newbies = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            newbies.add(Member.builder()
+                    .email(faker.internet().emailAddress())
+                    .realName(faker.name().fullName())
+                    .build());
+        }
+        return memberRepository.saveAll(newbies);
+    }
+
+    private <T> T pick(List<T> list) { return list.get(faker.random().nextInt(list.size())); }
+    private <E extends Enum<E>> E randomEnum(E[] values) { return values[faker.random().nextInt(values.length)]; }
+
+    /**
+     * Returns a random past LocalDateTime within the last `daysBack` days.
+     * Example: daysBack=90 -> anywhere between now-90d and now.
+     */
+    private LocalDateTime randomPastDateTime(int daysBack) {
+        long now = System.currentTimeMillis();
+        long earliest = now - (long) daysBack * 24L * 60L * 60L * 1000L;
+        long randomMillis = ThreadLocalRandom.current().nextLong(earliest, now);
+        return LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(randomMillis), java.time.ZoneId.systemDefault());
+    }
+}

--- a/src/main/java/com/wardk/meeteam_backend/web/project/controller/ProjectController.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/project/controller/ProjectController.java
@@ -4,6 +4,7 @@ import com.wardk.meeteam_backend.domain.project.service.ProjectService;
 import com.wardk.meeteam_backend.global.response.SuccessResponse;
 import com.wardk.meeteam_backend.global.auth.dto.CustomSecurityUserDetails;
 import com.wardk.meeteam_backend.web.project.dto.*;
+import com.wardk.meeteam_backend.web.projectLike.dto.ProjectWithLikeDto;
 import com.wardk.meeteam_backend.web.projectMember.dto.ProjectUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -48,11 +49,19 @@ public class ProjectController {
     }
 
     @Operation(summary = "프로젝트 상세 조회")
-    @GetMapping("/{projectId}")
-    public SuccessResponse<ProjectResponse> getProject(@PathVariable Long projectId) {
+    @GetMapping("V1/{projectId}")
+    public SuccessResponse<ProjectResponse> getProjectV1(@PathVariable Long projectId) {
 
-        ProjectResponse projectResponse = projectService.getProject(projectId);
+        ProjectResponse projectResponse = projectService.getProjectV1(projectId);
         return SuccessResponse.onSuccess(projectResponse);
+    }
+
+    @Operation(summary = "프로젝트 상세 조회")
+    @GetMapping("V2/{projectId}")
+    public SuccessResponse<ProjectWithLikeDto> getProjectV2(@PathVariable Long projectId) {
+
+        ProjectWithLikeDto projectV1 = projectService.getProjectV2(projectId);
+        return SuccessResponse.onSuccess(projectV1);
     }
 
     @Operation(summary = "프로젝트 수정")

--- a/src/main/java/com/wardk/meeteam_backend/web/project/controller/ProjectQueryController.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/project/controller/ProjectQueryController.java
@@ -3,6 +3,7 @@ package com.wardk.meeteam_backend.web.project.controller;
 import com.wardk.meeteam_backend.domain.project.repository.ProjectRepository;
 import com.wardk.meeteam_backend.domain.project.service.ProjectService;
 import com.wardk.meeteam_backend.global.response.SuccessResponse;
+import com.wardk.meeteam_backend.web.project.dto.ProjectConditionRequest;
 import com.wardk.meeteam_backend.web.project.dto.ProjectSearchCondition;
 import com.wardk.meeteam_backend.web.project.dto.ProjectSearchResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,14 +23,14 @@ public class ProjectQueryController {
 
     @Operation(summary = "프로젝트 조건 검색", description = "조건과 페이징을 기반으로 프로젝트 목록을 조회합니다.")
     @GetMapping("api/projects/condition")
-    public SuccessResponse<Slice<ProjectSearchResponse>> searchCondition(
+    public SuccessResponse<Slice<ProjectConditionRequest>> searchCondition(
             @ParameterObject ProjectSearchCondition condition,
             @ParameterObject Pageable pageable) {
 
 
-        Slice<ProjectSearchResponse> projectSearchResponses = projectService.searchProject(condition, pageable);
+        Slice<ProjectConditionRequest> projectConditionRequests = projectService.searchProject(condition, pageable);
 
-        return SuccessResponse.onSuccess(projectSearchResponses);
+        return SuccessResponse.onSuccess(projectConditionRequests);
 
     }
 

--- a/src/main/java/com/wardk/meeteam_backend/web/project/dto/ProjectConditionRequest.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/project/dto/ProjectConditionRequest.java
@@ -1,0 +1,44 @@
+package com.wardk.meeteam_backend.web.project.dto;
+
+import com.wardk.meeteam_backend.domain.project.entity.PlatformCategory;
+import com.wardk.meeteam_backend.domain.project.entity.Project;
+import com.wardk.meeteam_backend.domain.project.entity.ProjectCategory;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProjectConditionRequest {
+
+
+
+    private Long projectId;
+    private ProjectCategory projectCategory;
+    private PlatformCategory platformCategory;
+    private List<String> projectSkills;
+    private String projectName;
+    private String creatorName;
+    private LocalDate localDate;
+
+
+
+
+    public ProjectConditionRequest(Project project) {
+        this.projectId = project.getId();
+        this.projectCategory = project.getProjectCategory();
+        this.platformCategory = project.getPlatformCategory();
+        this.projectSkills = project.getProjectSkills()
+                .stream()
+                .map(projectSkill -> projectSkill.getSkill().getSkillName())
+                .toList();
+        this.projectName = project.getName();
+        this.creatorName = project.getCreator().getRealName();
+        this.localDate = LocalDate.from(project.getCreatedAt());
+    }
+
+}

--- a/src/main/java/com/wardk/meeteam_backend/web/project/dto/ProjectResponse.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/project/dto/ProjectResponse.java
@@ -18,6 +18,7 @@ public class ProjectResponse {
     private String name;
     private String description;
     private PlatformCategory platformCategory;
+    private Integer projectLike;
     private ProjectCategory projectCategory;
     private String imageUrl;
     private boolean offlineRequired;
@@ -32,6 +33,7 @@ public class ProjectResponse {
         return ProjectResponse.builder()
                 .name(project.getName())
                 .description(project.getDescription())
+                .projectLike(project.getLikeCount())
                 .platformCategory(project.getPlatformCategory())
                 .projectCategory(project.getProjectCategory())
                 .imageUrl(project.getImageUrl())

--- a/src/main/java/com/wardk/meeteam_backend/web/project/dto/ProjectSearchCondition.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/project/dto/ProjectSearchCondition.java
@@ -4,6 +4,7 @@ package com.wardk.meeteam_backend.web.project.dto;
 import com.wardk.meeteam_backend.domain.project.entity.PlatformCategory;
 import com.wardk.meeteam_backend.domain.project.entity.ProjectCategory;
 import com.wardk.meeteam_backend.domain.project.entity.Recruitment;
+import com.wardk.meeteam_backend.domain.project.entity.TechStack;
 import lombok.Data;
 
 @Data
@@ -17,5 +18,13 @@ public class ProjectSearchCondition {
     private PlatformCategory platformCategory;
 
     private String bigCategory;
+
+    private TechStack techStack;
+
+
+
+
+
+
 
 }

--- a/src/main/java/com/wardk/meeteam_backend/web/projectLike/controller/ProjectLikeController.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/projectLike/controller/ProjectLikeController.java
@@ -54,12 +54,12 @@ public class ProjectLikeController {
     private final ProjectLikeService projectLikeService;
 
 
-    @PostMapping("api/project/{projectId}")
+    @PostMapping("api/project/like/{projectId}")
     public SuccessResponse<ToggleLikeResponse> toggleLike(
             @PathVariable Long projectId,
             @AuthenticationPrincipal CustomSecurityUserDetails userDetails
     ) {
 
-        return SuccessResponse.onSuccess(projectLikeService.toggle(projectId, userDetails.getUsername()));
+        return SuccessResponse.onSuccess(projectLikeService.toggleWithOptimistic(projectId, userDetails.getUsername()));
     }
 }

--- a/src/main/java/com/wardk/meeteam_backend/web/projectLike/dto/ProjectWithLikeDto.java
+++ b/src/main/java/com/wardk/meeteam_backend/web/projectLike/dto/ProjectWithLikeDto.java
@@ -1,0 +1,62 @@
+package com.wardk.meeteam_backend.web.projectLike.dto;
+
+import com.wardk.meeteam_backend.domain.project.entity.PlatformCategory;
+import com.wardk.meeteam_backend.domain.project.entity.Project;
+import com.wardk.meeteam_backend.domain.project.entity.ProjectCategory;
+import com.wardk.meeteam_backend.web.project.dto.RecruitmentDto;
+import com.wardk.meeteam_backend.web.projectMember.dto.ProjectMemberListResponse;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@AllArgsConstructor
+@Data
+public class ProjectWithLikeDto {
+
+
+    private String name;
+    private String description;
+    private long likeCount;
+    private PlatformCategory platformCategory;
+    private ProjectCategory projectCategory;
+    private String imageUrl;
+    private boolean offlineRequired;
+    private LocalDate startDate; // 게시일이랑 프로젝트 시작일이랑 똑같은 건가?
+    private LocalDate endDate;
+    private List<ProjectMemberListResponse> projectMembers;
+    private List<String> skills;
+    private List<RecruitmentDto> recruitments;
+
+    public ProjectWithLikeDto(Project project, long likeCount) {
+        this.name = project.getName();
+        this.description = project.getDescription();
+        this.likeCount = likeCount;
+        this.platformCategory = project.getPlatformCategory();
+        this.projectCategory = project.getProjectCategory();
+        this.imageUrl = project.getImageUrl();
+        this.offlineRequired = project.isOfflineRequired();
+        this.startDate = project.getStartDate();
+        this.endDate = project.getEndDate();
+        this.projectMembers = project.getMembers().stream()
+                .map(member -> ProjectMemberListResponse.responseDto(
+                        member.getMember().getId(),
+                        member.getMember().getRealName(),
+                        member.getMember().getStoreFileName(),
+                        project.getCreator().getId().equals(member.getMember().getId())
+                ))
+                .toList();
+        this.skills = project.getProjectSkills().stream()
+                .map(ps -> ps.getSkill().getSkillName())
+                .toList();
+        this.recruitments = project.getRecruitments().stream()
+                .map(RecruitmentDto::responseDto)
+                .toList();
+
+    }
+
+
+
+
+}

--- a/src/test/java/com/wardk/meeteam_backend/domain/projectLike/service/ProjectLikeServiceTest.java
+++ b/src/test/java/com/wardk/meeteam_backend/domain/projectLike/service/ProjectLikeServiceTest.java
@@ -1,0 +1,106 @@
+package com.wardk.meeteam_backend.domain.projectLike.service;
+
+import com.wardk.meeteam_backend.domain.member.entity.Member;
+import com.wardk.meeteam_backend.domain.member.entity.UserRole;
+import com.wardk.meeteam_backend.domain.member.repository.MemberRepository;
+import com.wardk.meeteam_backend.domain.project.entity.Project;
+import com.wardk.meeteam_backend.domain.project.repository.ProjectRepository;
+import com.wardk.meeteam_backend.domain.projectLike.repository.ProjectLikeRepository;
+import com.wardk.meeteam_backend.global.config.QueryDslConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.springframework.test.context.transaction.TestTransaction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@Transactional
+@DataJpaTest
+@Import({QueryDslConfig.class, ProjectLikeService.class})
+class ProjectLikeServiceTest {
+
+    @Autowired
+    ProjectLikeService projectLikeService;
+
+    @Autowired
+    ProjectRepository projectRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    ProjectLikeRepository projectLikeRepository;
+
+    @Test
+    void 비관적락_좋아요_집계_정확성_테스트() throws InterruptedException {
+        // given
+        int threadCount = 20;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        Project project = new Project();
+        project.setName("Test Project");
+        project.setDescription("Test Description");
+        projectRepository.save(project);
+
+        List<Member> members = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            Member m = Member.builder()
+                    .email("test" + i + "@gmail.com")
+                    .role(UserRole.USER)
+                    .build();
+            members.add(memberRepository.save(m));
+        }
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        long start = System.currentTimeMillis();
+
+
+        System.out.println("-------------");
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executor.submit(() -> {
+                try {
+                    projectLikeService.toggleWithPessimistic(project.getId(), members.get(idx).getEmail());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        System.out.println("----------");
+
+        long end = System.currentTimeMillis();
+
+        System.out.println("비관적락time = " +  (end - start));
+
+        latch.await();
+        executor.shutdown();
+
+        // then
+        Project updated = projectRepository.findById(project.getId()).orElseThrow();
+
+        assertAll(
+                () -> assertEquals(threadCount, updated.getLikeCount()),
+                () -> assertEquals(threadCount,
+                        projectLikeRepository.countByProjectId(project.getId()))
+        );
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  sql:
+    init:
+      mode: never
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop  # 테스트 시작할 때 엔티티 기반으로 테이블 생성, 끝나면 삭제
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true


### PR DESCRIPTION

## 🛠️ 작업 내용

여러 명의 사용자가 프로젝트 좋아요 상태를 변경시 , Project 엔티티에 likeCount 필드에서 Lost update(갱신 유실)문제 발생,
DB에 갱신유실로 인해 좋아요 수 집계가 정확하지 않음


## 🎯 리뷰 포인트

동아리 프로젝트 모집기간이 아닌 경우, 동아리 인원유입 발생이 적을 것으로 예상되어, 좋아요 count 또한 충돌이 적을 것으로 예상한다.
하지만 동아리 모집기간 많은 사용자들이 비교적 적은 양의 프로젝트에 좋아요를 동시에 누를 가능성이 충분하다고 생각해서 다음과 같은 시나리오로 부하 테스트를 진행해 보았다.(nGrinder사용)

1. 평상시 (충돌 적음)
Vuser: 10명
Duration: 2분 (조금 길게 돌려서 안정화된 평균값 확보)
Ramp-up: 5~10초 정도 (사용자가 서서히 들어오는 느낌)
을 가정해서 nGrinder 을 이용해 성능 측정


2. 충돌 심한 상황 (Stress/Spike)
Vuser: 100명
Duration: 20초
Ramp-up 없음 (즉시 투입 → 충돌 극대화)
를 시나리오로 가정해서 nGrinder 를 이용해 부하테스트를 진행



**<평상시 (충돌적음) > 낙관적 락 사용**

<img width="421" height="375" alt="image" src="https://github.com/user-attachments/assets/4d3d5abd-ec11-480c-928c-7a2fe3e6f08e" />

**<평상시 (충돌적음) > 비관적 락 사용**

<img width="407" height="412" alt="image" src="https://github.com/user-attachments/assets/0c0930d6-0344-4af6-87df-026750897712" />


평상시 시나리오(충돌이적을시)에 유의미한 성능차이를 보이지 않았다.(동시에 요청하는 경우가 거의 없어 성능차이 없을것으로 예상)


**충돌 심한 상황 (Stress/Spike) 낙관적 락 사용**
<img width="478" height="370" alt="image" src="https://github.com/user-attachments/assets/ab9d0046-dee9-45d6-a603-50282d14f9e6" />


**충돌 심한 상황 (Stress/Spike) 비관적 락 사용**
<img width="462" height="382" alt="image" src="https://github.com/user-attachments/assets/482b7324-6a05-48bd-b3f1-77dc53100df1" />


충돌이 심한 상황에서 왜 비관적 락이 응답시간, TPS 모두 좋게 나올지 생각해 보았다.
비관적락과 낙관적락의 차이점은, 조회시점에  X-락의 사용 유무이다.(조회시점 락을 가져가는지)
하지만 좋아요 특성상 매우 가벼운 작업이므로 조회시점(select) 와 수정시점(update) 가 매우매우 짧다.
<img width="624" height="361" alt="image" src="https://github.com/user-attachments/assets/248c0e4c-78c6-4b31-9079-3662714c715f" />

그럼 왜 낙관적 락의 응답시간이 비관적 락의 응답시간 보다 작을까
`낙관적락 : 20초동안 100명의 사용자 응답시간 : 103ms`
`비관적락 : 20초동안 100명의 사용자 응답시간 : 81ms`

**충돌시 트랜잭션 재시작에 의한 성능 저하 폭 > 비관적 락의 성능 저하 폭** 으로 인해 이러한 성능이 나온것을 예상할 수 있다.






