### PR TITLE
OAuth2 하드코딩 제거 및 Redis 세션 저장소 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
 
 	// Spring WebSocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/src/main/java/com/wardk/meeteam_backend/MeeteamBackendApplication.java
+++ b/src/main/java/com/wardk/meeteam_backend/MeeteamBackendApplication.java
@@ -2,11 +2,13 @@ package com.wardk.meeteam_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class MeeteamBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/wardk/meeteam_backend/global/config/OAuth2Properties.java
+++ b/src/main/java/com/wardk/meeteam_backend/global/config/OAuth2Properties.java
@@ -1,0 +1,87 @@
+package com.wardk.meeteam_backend.global.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * OAuth2 관련 외부 설정을 관리하는 Properties 클래스
+ * application.yml의 app.oauth2 설정을 바인딩
+ */
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "app.oauth2")
+public class OAuth2Properties {
+
+    //리다이렉트 관련 설정
+    private final Redirect redirect;
+
+    //프로바이더별 설정
+    private final Providers providers;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Redirect {
+
+        //OAuth2 성공 시 프론트엔드 베이스 URL
+        private final String successBaseUrl;
+
+        //OAuth2 성공 시 리다이렉트 경로
+        private final String successPath;
+
+        //OAuth2 실패 시 프론트엔드 베이스 URL
+        private final String failureBaseUrl;
+
+        //OAuth2 실패 시 리다이렉트 경로
+        private final String failurePath;
+
+        //OAuth2 실패 처리 엔드포인트
+        private final String failureEndpoint;
+
+        //성공 시 완전한 리다이렉트 URL 생성
+        public String getSuccessUrl() {
+            return successBaseUrl + successPath;
+        }
+
+        //실패 시 완전한 리다이렉트 URL 생성
+        public String getFailureUrl() {
+            return failureBaseUrl + failurePath;
+        }
+
+        //토큰과 함께 성공 리다이렉트 URL 생성
+        public String getSuccessUrlWithToken(String token) {
+            return getSuccessUrl() + "?token=" + token;
+        }
+
+        //에러와 함께 실패 리다이렉트 URL 생성
+        public String getFailureUrlWithError(String error) {
+            return getFailureUrl() + "?error=" + error;
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Providers {
+        private final Google google;
+        private final Github github;
+
+        @Getter
+        @RequiredArgsConstructor
+        public static class Google {
+            private final String name;
+            private final String userNameAttribute;
+            private final String emailAttribute;
+            private final String idAttribute;
+        }
+
+        @Getter
+        @RequiredArgsConstructor
+        public static class Github {
+            private final String name;
+            private final String userNameAttribute;
+            private final String loginAttribute;
+            private final String emailAttribute;
+            private final String idAttribute;
+        }
+    }
+}

--- a/src/main/java/com/wardk/meeteam_backend/global/config/RedisConfig.java
+++ b/src/main/java/com/wardk/meeteam_backend/global/config/RedisConfig.java
@@ -8,8 +8,10 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @Configuration
+@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 1800) // 30분 세션 유지
 public class RedisConfig {
 
     @Bean
@@ -33,5 +35,21 @@ public class RedisConfig {
 
         template.afterPropertiesSet();
         return template;
+    }
+
+    // Redis 세션용 RedisTemplate 추가 (Spring Session이 사용)
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        // Spring Session에서 사용하는 기본 직렬화 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
     }
 }

--- a/src/main/java/com/wardk/meeteam_backend/global/config/SecurityUrls.java
+++ b/src/main/java/com/wardk/meeteam_backend/global/config/SecurityUrls.java
@@ -27,8 +27,7 @@ public class SecurityUrls {
             "/oauth2/**",
             "/login/oauth2/**",
             "/login/oauth2/code/**",
-            "/api/auth/oauth2/success",
-            "/api/auth/oauth2/failure",
+            "/api/auth/oauth2/**",
             "/api/webhooks/github",
             "/api/v1/files/**"  // 파일 업로드 API 경로 추가
             ,"index.html"


### PR DESCRIPTION
주요 변경사항

- OAuth2 하드코딩 제거: 환경변수 기반 동적 URL 관리 구현
- Redis 세션 저장소 도입: 분산 환경에서의 세션 공유 및 안정성 확보
- CORS 설정 강화: 배포 환경 도메인 추가 및 쿠키 전송 허용

구현 세부사항
1. OAuth2Properties 설정 클래스 추가

2. OAuth2AuthenticationSuccessHandler 리팩토링
- 하드코딩된 URL 제거 (localhost:3000 → 환경변수 기반)
- OAuth2Properties 의존성 주입으로 동적 URL 생성

3. Redis 세션 저장소 구성
- RedisConfig: Redis 세션 설정 (@EnableRedisHttpSession)
- CookieSerializer: Spring Security 6.x 호환 쿠키 설정
- 세션 만료시간: 30분 설정으로 보안성과 편의성 균형
